### PR TITLE
Do not run the server on import

### DIFF
--- a/xiplot/__main__.py
+++ b/xiplot/__main__.py
@@ -1,5 +1,5 @@
 from xiplot.setup import setup_xiplot_dash_app
 
-app = setup_xiplot_dash_app(unsafe_local_server=True)
-
-app.run(debug=True)
+if __name__ == "__main__":
+  app = setup_xiplot_dash_app(unsafe_local_server=True)
+  app.run(debug=True)


### PR DESCRIPTION
This change only starts the server when the script is called directly.

Additional suggestion: read command line arguments for `debug=True` and `unsafe_local_server=True` (not implemented here).