### PR TITLE
Improve the css

### DIFF
--- a/xiplot/assets/dcc_style.css
+++ b/xiplot/assets/dcc_style.css
@@ -125,10 +125,6 @@
     stroke-width: 1px !important;
 }
 
-.ycbcoloraxistick text {
-    fill: white !important;
-}
-
 @media all and (min-width:0px) and (max-width: 320px) {
     .dash-uploader {
         height: 50px !important;

--- a/xiplot/assets/dcc_style.css
+++ b/xiplot/assets/dcc_style.css
@@ -93,6 +93,10 @@
     color: var(--placeholder-color) !important;
 }
 
+.tab.jsx-3201076643 {
+    padding: 20px 25px 5px 25px;
+}
+
 .tab.jsx-3201076643.tab,
 .tab.jsx-3201076643:last-of-type {
     background-color: transparent;
@@ -102,18 +106,22 @@
 }
 
 .tab.jsx-3201076643.tab:hover {
-    border-bottom: 2px solid #C5C6C7 !important;
+    border-bottom: 4px solid #C5C6C7 !important;
 }
 
 .tab.jsx-3201076643.tab.tab--selected {
     color: black !important;
     color: var(--font-color) !important;
-    border-bottom: 2px solid rgb(214, 214, 214) !important;
-    border-bottom: 2px solid var(--selected-tab-underline) !important;
+    border-bottom: 4px solid rgb(214, 214, 214) !important;
+    border-bottom: 4px solid var(--selected-tab-underline) !important;
 }
 
 .tab.jsx-3201076643.tab.tab--selected:hover {
     background-color: transparent;
+}
+
+.tab-content {
+    padding: 10px;
 }
 
 .xgrid.crisp,

--- a/xiplot/assets/dcc_style.css
+++ b/xiplot/assets/dcc_style.css
@@ -42,24 +42,31 @@
 }
 
 .dcc-upload {
-    width: 100%;
-    /*height: 60px;
-    line-height: 60px;*/
+    width: auto;
     border-width: 1px;
     border-style: dashed;
     border-radius: 5px;
     margin: 10px;
-
     text-align: center;
+    min-height: 1;
+    padding: 2em 1em 2em 1em;
 }
 
 .dash-uploader {
     position: relative;
-
     display: inline-block;
-    width: 40%;
-    margin-left: 16%;
-    top: 10px;
+    flex: 1;
+    min-height: 1;
+    align-self: stretch;
+    min-width: 12em;
+    margin: 0em;
+    margin-bottom: auto;
+    margin-top: auto;
+}
+
+.dash-uploader>* {
+    margin: 1em;
+    width: auto !important;
 }
 
 .main-svg {
@@ -131,26 +138,4 @@
     stroke: white !important;
     stroke-opacity: 1 !important;
     stroke-width: 1px !important;
-}
-
-@media all and (min-width:0px) and (max-width: 320px) {
-    .dash-uploader {
-        height: 50px !important;
-        font-size: 11px !important;
-    }
-
-    .dash-uploader-default,
-    .dash-uploader-hovered {
-        height: 100% !important;
-        line-height: 0px !important;
-    }
-}
-
-@media all and (min-width:321px) and (max-width: 480px) {
-
-    .dash-uploader-default,
-    .dash-uploader-hovered {
-        margin-left: 20px !important;
-        width: 170px !important;
-    }
 }

--- a/xiplot/assets/dcc_style.css
+++ b/xiplot/assets/dcc_style.css
@@ -49,7 +49,7 @@
     margin: 10px;
     text-align: center;
     min-height: 1;
-    padding: 2em 1em 2em 1em;
+    padding: 2rem 1rem 2rem 1rem;
 }
 
 .dash-uploader {
@@ -58,14 +58,14 @@
     flex: 1;
     min-height: 1;
     align-self: stretch;
-    min-width: 12em;
-    margin: 0em;
+    min-width: 12rem;
+    margin: 0px;
     margin-bottom: auto;
     margin-top: auto;
 }
 
 .dash-uploader>* {
-    margin: 1em;
+    margin: 1rem;
     width: auto !important;
 }
 

--- a/xiplot/assets/html_components.css
+++ b/xiplot/assets/html_components.css
@@ -21,7 +21,7 @@ button {
 }
 
 .button {
-    padding: 0.75rem 1rem;
+    padding: 0.45rem 1rem;
 }
 
 .button:hover,
@@ -70,4 +70,21 @@ button.delete:active,
 .light-dark-toggle {
     background-color: transparent;
     color: var(--font-color);
+}
+
+.flex-row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: end;
+}
+
+.flex-row .dash-dropdown {
+    min-width: 12em;
+    flex: 1;
+}
+
+.stretch {
+    flex: 1;
 }

--- a/xiplot/assets/html_components.css
+++ b/xiplot/assets/html_components.css
@@ -81,7 +81,7 @@ button.delete:active,
 }
 
 .flex-row .dash-dropdown {
-    min-width: 12em;
+    min-width: 12rem;
     flex: 1;
 }
 

--- a/xiplot/assets/html_components.css
+++ b/xiplot/assets/html_components.css
@@ -1,4 +1,5 @@
-.button {
+.button,
+button {
     background-color: transparent;
     border: 1px solid rgb(209, 213, 219);
     box-sizing: border-box;
@@ -6,27 +7,64 @@
     color: var(--font-color);
     font-size: .875rem;
     line-height: 1.25rem;
-    padding: .75rem 1rem;
     text-align: center;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.1);
     cursor: pointer;
     user-select: none;
     -webkit-user-select: none;
     touch-action: manipulation;
+    border-radius: 4px;
 }
 
-.button:hover {
+button {
+    padding: 0.2rem 0.5rem;
+}
+
+.button {
+    padding: 0.75rem 1rem;
+}
+
+.button:hover,
+button:hover {
     background-color: rgb(249, 250, 251);
     color: #1F2833;
 }
 
-.button:focus {
+.button:active,
+button:active {
+    background-color: rgb(192, 192, 192);
+    color: #1F2833;
+}
+
+.button:focus,
+button:focus {
     outline: 2px solid transparent;
     outline-offset: 2px;
 }
 
-.button:focus-visible {
+.button:focus-visible,
+button:focus-visible {
     box-shadow: none;
+}
+
+button.delete,
+.button.delete {
+    font-size: large;
+    font-weight: 900;
+    background-color: red;
+    color: white;
+}
+
+button.delete:hover,
+.button.delete:hover {
+    background-color: white;
+    color: red;
+}
+
+button.delete:active,
+.button.delete:active {
+    background-color: red;
+    color: red;
 }
 
 .light-dark-toggle {

--- a/xiplot/assets/stylesheet.css
+++ b/xiplot/assets/stylesheet.css
@@ -51,18 +51,28 @@ body {
     color: var(--font-color)
 }
 
+#plots {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: center;
+    align-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+}
+
 .plots {
     display: block;
-    width: 32%;
-    float: left;
-    height: 650px;
+    min-width: 35em;
+    flex: 1 1 32%;
     background-color: #dffcde !important;
     background-color: var(--control-bg-color) !important;
-    margin: 10px 10px 10px 10px;
     border-radius: 8px;
     box-shadow: 0px 4px 5px 0px hsla(0, 0%, 0%, 0.14),
         0px 1px 10px 0px hsla(0, 0%, 0%, 0.12),
         0px 2px 4px -1px hsla(0, 0%, 0%, 0.2);
+    padding: 5px;
 }
 
 .smiles-img {
@@ -72,12 +82,4 @@ body {
     margin-left: auto;
     margin-right: auto;
     background-color: var(--smiles-img-bg-color);
-}
-
-
-@media all and (min-width:0px) and (max-width: 480px) {
-    .plots {
-        width: 100% !important;
-        margin: 10px 0px 0px 0px !important;
-    }
 }

--- a/xiplot/assets/stylesheet.css
+++ b/xiplot/assets/stylesheet.css
@@ -46,9 +46,13 @@ body {
 
 .logo {
     text-align: center;
-    margin: 20;
+    margin: 0;
     color: black;
     color: var(--font-color)
+}
+
+.logo>h1 {
+    margin: 0.2em;
 }
 
 #plots {
@@ -72,7 +76,7 @@ body {
     box-shadow: 0px 4px 5px 0px hsla(0, 0%, 0%, 0.14),
         0px 1px 10px 0px hsla(0, 0%, 0%, 0.12),
         0px 2px 4px -1px hsla(0, 0%, 0%, 0.2);
-    padding: 5px;
+    padding: 10px;
 }
 
 .smiles-img {

--- a/xiplot/assets/stylesheet.css
+++ b/xiplot/assets/stylesheet.css
@@ -9,6 +9,7 @@
     --graph-stroke: white;
     --tab-underline: #adb5bd;
     --selected-tab-underline: #198754;
+    --base-column-size: 30%;
 }
 
 [data-theme="dark"] {
@@ -22,6 +23,22 @@
     --graph-stroke: #3f3f3f;
     --tab-underline: #45A29E;
     --selected-tab-underline: #D6D6D6;
+}
+
+[data-cols="1"] .plots {
+    --base-column-size: 80%;
+}
+
+[data-cols="2"] .plots {
+    --base-column-size: 40%;
+}
+
+[data-cols="4"] .plots {
+    --base-column-size: 22%;
+}
+
+[data-cols="5"] .plots {
+    --base-column-size: 18%;
 }
 
 body {
@@ -69,7 +86,7 @@ body {
 .plots {
     display: block;
     min-width: 20rem;
-    flex: 1 1 32%;
+    flex: 1 1 var(--base-column-size);
     background-color: #dffcde !important;
     background-color: var(--control-bg-color) !important;
     border-radius: 8px;

--- a/xiplot/assets/stylesheet.css
+++ b/xiplot/assets/stylesheet.css
@@ -52,7 +52,7 @@ body {
 }
 
 .logo>h1 {
-    margin: 0.2em;
+    margin: 0.2rem;
 }
 
 #plots {
@@ -68,7 +68,7 @@ body {
 
 .plots {
     display: block;
-    min-width: 35em;
+    min-width: 20rem;
     flex: 1 1 32%;
     background-color: #dffcde !important;
     background-color: var(--control-bg-color) !important;

--- a/xiplot/tabs/cluster.py
+++ b/xiplot/tabs/cluster.py
@@ -17,6 +17,7 @@ from xiplot.utils.layouts import layout_wrapper, cluster_dropdown
 from xiplot.utils.regex import dropdown_regex, get_columns_by_regex
 from xiplot.utils.dataframe import get_numeric_columns
 from xiplot.utils.cluster import cluster_colours
+from xiplot.utils.components import FlexRow
 
 
 class Cluster(Tab):
@@ -448,74 +449,60 @@ class Cluster(Tab):
     def create_layout():
         return html.Div(
             [
-                layout_wrapper(
-                    component=dcc.Dropdown(
-                        options=[i for i in range(2, len(cluster_colours()))],
-                        id="cluster_amount",
+                FlexRow(
+                    layout_wrapper(
+                        component=FlexRow(
+                            dcc.Dropdown(id="cluster_feature", multi=True),
+                            html.Button(
+                                "Add features by regex",
+                                id="add_by_keyword-button",
+                                className="button",
+                            ),
+                        ),
+                        css_class="stretch",
+                        title="features",
                     ),
-                    css_class="dd-double-right",
-                    title="cluster amount",
-                ),
-                layout_wrapper(
-                    component=dcc.Dropdown(id="cluster_feature", multi=True),
-                    css_class="dd-double-right",
-                    title="features",
+                    layout_wrapper(
+                        component=FlexRow(
+                            dcc.Dropdown(
+                                options=[i for i in range(2, len(cluster_colours()))],
+                                id="cluster_amount",
+                            ),
+                            html.Button(
+                                "Compute the clusters",
+                                id="cluster-button",
+                                className="button",
+                            ),
+                        ),
+                        css_class="stretch",
+                        title="cluster amount",
+                    ),
                 ),
                 layout_wrapper(
                     component=dcc.Input(id="feature_keyword-input"),
                     style={"display": "none"},
                 ),
-                html.Button(
-                    "Add features by regex",
-                    id="add_by_keyword-button",
-                    style={"padding-top": "20"},
-                    className="button",
-                ),
-                html.Div(),
-                html.Div(
-                    [
-                        html.Button(
-                            "Compute the clusters",
-                            id="cluster-button",
-                            className="button",
-                            style={
-                                "margin-left": "auto",
-                                "margin-right": "auto",
-                            },
-                        ),
-                        html.Button(
-                            "Reset the clusters",
-                            id="clusters_reset-button",
-                            className="button",
-                            style={
-                                "margin-left": "auto",
-                                "margin-right": "auto",
-                            },
-                        ),
-                    ],
-                    style={
-                        "margin-top": "1%",
-                        "margin-left": "5%",
-                        "display": "flex",
-                        "width": "20%",
-                    },
-                ),
-                html.Div(),
-                cluster_dropdown(
-                    id_name="selection_cluster_dropdown",
-                    value="c1",
-                    disabled=True,
-                    css_class="dd-double-left",
-                    title="Selection Cluster",
-                    style={"margin-left": "2%"},
-                ),
-                layout_wrapper(
-                    component=daq.ToggleSwitch(
-                        id="cluster_selection_mode",
-                        value=False,
-                        label="replace mode/edit mode",
+                html.Br(),
+                FlexRow(
+                    cluster_dropdown(
+                        id_name="selection_cluster_dropdown",
+                        value="c1",
+                        disabled=True,
+                        css_class="dash-dropdown",
+                        title="Selection Cluster",
                     ),
-                    style={"display": "inline-block"},
+                    layout_wrapper(
+                        component=daq.ToggleSwitch(
+                            id="cluster_selection_mode",
+                            value=False,
+                            label="replace mode/edit mode",
+                        )
+                    ),
+                    html.Button(
+                        "Reset the clusters",
+                        id="clusters_reset-button",
+                        className="button",
+                    ),
                 ),
             ],
             id="control_clusters_content-container",

--- a/xiplot/tabs/data.py
+++ b/xiplot/tabs/data.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from dash import Output, Input, State, ctx, html, dcc
 from dash.exceptions import PreventUpdate
 from dash_extensions.enrich import ServersideOutput
+from xiplot.utils.components import FlexRow
 
 from xiplot.utils.dataframe import (
     read_dataframe_with_extension,
@@ -483,87 +484,67 @@ class Data(Tab):
             uploader = du.Upload(
                 id="file_uploader",
                 text="Drag and Drop or Select a File to upload",
-                default_style={"minHeight": 1, "lineHeight": 4, "height": "85px"},
+                default_style={"minHeight": 1, "lineHeight": 4},
             )
         except (ImportError, AttributeError):
             uploader = dcc.Upload(
                 id="file_uploader",
                 children=html.Div(
-                    [
-                        "Drag and Drop or ",
-                        html.A("Select a File"),
-                        " to upload",
-                    ]
+                    ["Drag and Drop or ", html.A("Select a File"), " to upload"]
                 ),
                 className="dcc-upload",
             )
 
-        return html.Div(
-            [
-                html.Div(
-                    [
-                        layout_wrapper(
-                            component=dcc.Dropdown(
+        return FlexRow(
+            html.Div(
+                [
+                    layout_wrapper(
+                        component=FlexRow(
+                            dcc.Dropdown(
                                 [
                                     {"label": fp.name, "value": str(fp)}
                                     for fp in get_data_filepaths()
                                 ],
                                 id="data_files",
-                                className="dd",
                             ),
-                            title="Choose a data file",
-                            css_class="dd",
-                            style={"margin-left": "5%", "width": "100%"},
+                            html.Button(
+                                "Load",
+                                id="submit-button",
+                                n_clicks=0,
+                                className="button",
+                            ),
                         ),
-                        html.Div(
-                            [
-                                html.Button(
-                                    "Load the data file",
-                                    id="submit-button",
-                                    n_clicks=0,
-                                    className="button",
-                                    style={
-                                        "margin-left": "auto",
-                                        "margin-right": "auto",
-                                    },
-                                ),
-                                html.Button(
-                                    "Download only the data file",
-                                    id="download-data-file-button",
-                                    n_clicks=0,
-                                    className="button",
-                                    style={
-                                        "margin-left": "auto",
-                                        "margin-right": "auto",
-                                    },
-                                ),
-                                html.Button(
-                                    "Download the combined plots-and-data file",
-                                    id="download-plots-file-button",
-                                    n_clicks=0,
-                                    className="button",
-                                    style={
-                                        "margin-left": "auto",
-                                        "margin-right": "auto",
-                                    },
-                                ),
-                                dcc.Download(
-                                    id="data-download",
-                                ),
-                            ],
-                            style={
-                                "margin-top": "1%",
-                                "margin-left": "5%",
-                                "display": "flex",
-                            },
-                        ),
-                    ],
-                    style={"float": "left", "width": "40%"},
-                ),
-                html.Div(
-                    [uploader], id="file_uploader_container", className="dash-uploader"
-                ),
-            ],
+                        title="Choose a data file",
+                        css_class="dash-dropdown",
+                    ),
+                    html.Br(),
+                    html.Div(
+                        [
+                            html.Div("Download the data"),
+                            html.Button(
+                                "Download only the data",
+                                id="download-data-file-button",
+                                n_clicks=0,
+                                className="button",
+                            ),
+                            " ",
+                            html.Button(
+                                "Download a plots and data",
+                                id="download-plots-file-button",
+                                n_clicks=0,
+                                className="button",
+                            ),
+                            dcc.Download(
+                                id="data-download",
+                            ),
+                        ],
+                    ),
+                ],
+                className="stretch",
+            ),
+            html.Div(
+                [uploader], id="file_uploader_container", className="dash-uploader"
+            ),
             id="control_data_content-container",
         )
 

--- a/xiplot/tabs/embedding.py
+++ b/xiplot/tabs/embedding.py
@@ -7,6 +7,7 @@ from dash import html, Input, Output, State, dcc, ctx
 import dash_mantine_components as dmc
 
 from xiplot.tabs import Tab
+from xiplot.utils.components import FlexRow
 from xiplot.utils.layouts import layout_wrapper
 from xiplot.utils.dataframe import get_numeric_columns
 from xiplot.utils.embedding import get_pca_columns
@@ -195,28 +196,22 @@ class Embedding(Tab):
 
     @staticmethod
     def create_layout():
-        return html.Div(
-            [
-                layout_wrapper(
-                    dcc.Dropdown(id="embedding_type", options=["PCA"]),
-                    css_class="dd-double-right",
-                    title="Embedding type",
-                ),
-                layout_wrapper(
-                    component=dcc.Dropdown(id="embedding_feature", multi=True),
-                    css_class="dd-double-right",
-                    title="Features",
-                ),
-                html.Button(
-                    "Compute the embedding",
-                    id="embedding-button",
-                    className="button",
-                    style={
-                        "margin-left": "auto",
-                        "margin-right": "auto",
-                    },
-                ),
-            ],
+        return FlexRow(
+            layout_wrapper(
+                dcc.Dropdown(id="embedding_type", options=["PCA"]),
+                css_class="dash-dropdown",
+                title="Embedding type",
+            ),
+            layout_wrapper(
+                component=dcc.Dropdown(id="embedding_feature", multi=True),
+                css_class="dash-dropdown",
+                title="Features",
+            ),
+            html.Button(
+                "Compute the embedding",
+                id="embedding-button",
+                className="button",
+            ),
             id="control-embedding-container",
         )
 

--- a/xiplot/tabs/plots.py
+++ b/xiplot/tabs/plots.py
@@ -18,6 +18,7 @@ from xiplot.plots.heatmap import Heatmap
 from xiplot.plots.barplot import Barplot
 from xiplot.plots.table import Table
 from xiplot.plots.smiles import Smiles
+from xiplot.utils.components import FlexRow
 
 
 def load_plugins_plot():
@@ -240,13 +241,15 @@ class Plots(Tab):
         return html.Div(
             [
                 layout_wrapper(
-                    component=dcc.Dropdown(
-                        options=list(Plots.plot_types.keys()), id="plot_type"
+                    component=FlexRow(
+                        dcc.Dropdown(
+                            options=list(Plots.plot_types.keys()), id="plot_type"
+                        ),
+                        html.Button("Add", id="new_plot-button", className="button"),
                     ),
                     title="Select a plot type",
-                    style={"width": "98%"},
+                    # style={"width": "98%"},
                 ),
-                html.Button("Add", id="new_plot-button", className="button"),
             ],
             id="control_plots_content-container",
         )

--- a/xiplot/tabs/settings.py
+++ b/xiplot/tabs/settings.py
@@ -28,7 +28,7 @@ class Settings(Tab):
                     component=html.Button(
                         "Dark",
                         id="light-dark-toggle",
-                        className="light-dark-toggle",
+                        className="light-dark-toggle button",
                     ),
                     title="Light/Dark mode",
                 )

--- a/xiplot/tabs/settings.py
+++ b/xiplot/tabs/settings.py
@@ -1,7 +1,8 @@
 from xiplot.tabs import Tab
+from xiplot.utils.components import FlexRow
 from xiplot.utils.layouts import layout_wrapper
 
-from dash import html, Input, Output
+from dash import html, Input, Output, dcc
 
 
 class Settings(Tab):
@@ -20,18 +21,36 @@ class Settings(Tab):
             Output("light-dark-toggle", "children"),
             Input("light-dark-toggle", "n_clicks"),
         )
+        app.clientside_callback(
+            """
+            function changeColSize(cols) {
+                document.documentElement.setAttribute("data-cols", cols)
+                return cols
+            }
+            """,
+            Output("settings-column-size", "value"),
+            Input("settings-column-size", "value"),
+        )
 
     def create_layout():
-        return html.Div(
-            [
-                layout_wrapper(
-                    component=html.Button(
-                        "Dark",
-                        id="light-dark-toggle",
-                        className="light-dark-toggle button",
-                    ),
-                    title="Light/Dark mode",
-                )
-            ],
+        return FlexRow(
+            layout_wrapper(
+                component=html.Button(
+                    "Dark",
+                    id="light-dark-toggle",
+                    className="light-dark-toggle button",
+                ),
+                title="Light/Dark mode",
+            ),
+            " ",
+            layout_wrapper(
+                component=dcc.Dropdown(
+                    ["1", "2", "3", "4", "5"],
+                    "3",
+                    clearable=False,
+                    id="settings-column-size",
+                ),
+                title="Maximum number of columns",
+            ),
             id="control-settings-container",
         )

--- a/xiplot/utils/components.py
+++ b/xiplot/utils/components.py
@@ -3,9 +3,19 @@ from dash import dcc, html
 
 
 class FlexRow(html.Div):
-    def __init__(self, *components, className: Optional[str] = None, **kwargs):
+    """
+    Create a Div with a "display: flex" style.
+    This makes the children appear on one line (with wrapping if necessary).
+    Any child with a `className="stretch"` will fill all the empty space of the line.
+    `dcc.Dropdown` automatically stretch with a minimum length (see `html_components.css`).
+
+    Example:
+        row = FlexRow(dcc.Dropown(["A", "B"]), html.Button("Accept"), id="example")
+    """
+
+    def __init__(self, *children, className: Optional[str] = None, **kwargs):
         if className is None:
             className = "flex-row"
         else:
             className = className + " flex-row"
-        super().__init__(children=list(components), className=className, **kwargs)
+        super().__init__(children=list(children), className=className, **kwargs)

--- a/xiplot/utils/components.py
+++ b/xiplot/utils/components.py
@@ -1,0 +1,11 @@
+from typing import Optional
+from dash import dcc, html
+
+
+class FlexRow(html.Div):
+    def __init__(self, *components, className: Optional[str] = None, **kwargs):
+        if className is None:
+            className = "flex-row"
+        else:
+            className = className + " flex-row"
+        super().__init__(children=list(components), className=className, **kwargs)

--- a/xiplot/utils/layouts.py
+++ b/xiplot/utils/layouts.py
@@ -44,9 +44,7 @@ def delete_button(type, index):
 
         html.Button element
     """
-    return html.Button(
-        "x", id={"type": type, "index": index}, style={"background-color": "red"}
-    )
+    return html.Button("x", id={"type": type, "index": index}, className="delete")
 
 
 def cluster_dropdown(


### PR DESCRIPTION
This PR contains various improvements to the css. But mainly:

- Use "flexbox" for the plot grid. This can better handle different screen sizes.
- Add a setting for the (maximum) number of columns in the plot grid.
- Use "flexbox" for the grids in the tabs. For more consistent spacing and height reduction.
- Smaller tweaks:
  -  Add padding to the panels.
  - Rounded corners (and a more consistent style) for the buttons.
  - removed some css that made text white.