### PR TITLE
Plotly templates

### DIFF
--- a/xiplot/assets/dcc_style.css
+++ b/xiplot/assets/dcc_style.css
@@ -77,7 +77,8 @@
 
 .Select-control,
 .Select-menu-outer,
-.Select-input:focus {
+.Select-input,
+.Select-input input {
     background-color: white !important;
     background-color: var(--bg-color) !important;
     color: black;

--- a/xiplot/assets/dcc_style.css
+++ b/xiplot/assets/dcc_style.css
@@ -70,7 +70,8 @@
 }
 
 .Select-control,
-.Select-menu-outer {
+.Select-menu-outer,
+.Select-input:focus {
     background-color: white !important;
     background-color: var(--bg-color) !important;
 }
@@ -126,4 +127,35 @@
 
 .tab-content {
     padding: 10px;
+}
+
+.dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner table th {
+    color: black;
+    color: var(--font-color);
+    background-color: white;
+    background-color: var(--bg-color);
+}
+
+.dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type="radio"]):not([type="checkbox"]) {
+    color: black;
+    color: var(--font-color);
+}
+
+[data-theme="dark"] .dash-spreadsheet {
+    border: 1px solid gray;
+    border-top: 0px;
+}
+
+.dash-spreadsheet-menu .dash-spreadsheet-menu-item .show-hide-menu {
+    color: black;
+    color: var(--font-color);
+    background-color: white;
+    background-color: var(--bg-color);
+}
+
+.dash-table-container .previous-next-container button.previous-page,
+.dash-table-container .previous-next-container button.next-page,
+.dash-table-container .previous-next-container button.first-page,
+.dash-table-container .previous-next-container button.last-page {
+    border: 1px solid rgb(209, 213, 219);
 }

--- a/xiplot/assets/dcc_style.css
+++ b/xiplot/assets/dcc_style.css
@@ -45,7 +45,8 @@
     width: auto;
     border-width: 1px;
     border-style: dashed;
-    border-radius: 5px;
+    border-radius: 8px;
+    border-radius: var(--large-radius);
     margin: 10px;
     text-align: center;
     min-height: 1;
@@ -64,6 +65,11 @@
     margin-top: auto;
 }
 
+.dash-uploader-default {
+    border-radius: 8px !important;
+    border-radius: var(--large-radius) !important;
+}
+
 .dash-uploader>* {
     margin: 1rem;
     width: auto !important;
@@ -74,6 +80,8 @@
 .Select-input:focus {
     background-color: white !important;
     background-color: var(--bg-color) !important;
+    color: black;
+    color: var(--font-color);
 }
 
 .is-disabled .Select-control,
@@ -129,17 +137,15 @@
     padding: 10px;
 }
 
-.dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner table th {
+.dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner table,
+.dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner th,
+.dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type="radio"]):not([type="checkbox"]) {
     color: black;
     color: var(--font-color);
     background-color: white;
     background-color: var(--bg-color);
 }
 
-.dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type="radio"]):not([type="checkbox"]) {
-    color: black;
-    color: var(--font-color);
-}
 
 [data-theme="dark"] .dash-spreadsheet {
     border: 1px solid gray;
@@ -158,4 +164,14 @@
 .dash-table-container .previous-next-container button.first-page,
 .dash-table-container .previous-next-container button.last-page {
     border: 1px solid rgb(209, 213, 219);
+}
+
+.rc-slider-mark-text {
+    color: darkgray;
+    color: var(--font-disabled-color)
+}
+
+.rc-slider-mark-text-active {
+    color: black;
+    color: var(--font-color)
 }

--- a/xiplot/assets/dcc_style.css
+++ b/xiplot/assets/dcc_style.css
@@ -69,22 +69,6 @@
     width: auto !important;
 }
 
-.main-svg {
-    background-color: transparent !important;
-}
-
-.bg {
-    fill: var(--graph-bg-color);
-}
-
-.ytick text,
-.xtick text,
-.g-gtitle text,
-.g-xtitle text,
-.g-ytitle text {
-    fill: var(--font-color) !important;
-}
-
 .Select-control,
 .Select-menu-outer {
     background-color: white !important;
@@ -142,13 +126,4 @@
 
 .tab-content {
     padding: 10px;
-}
-
-.xgrid.crisp,
-.ygrid.crisp,
-.xzl.zl.crisp,
-.yzl.zl.crisp {
-    stroke: white !important;
-    stroke-opacity: 1 !important;
-    stroke-width: 1px !important;
 }

--- a/xiplot/assets/html_components.css
+++ b/xiplot/assets/html_components.css
@@ -13,7 +13,8 @@ button {
     user-select: none;
     -webkit-user-select: none;
     touch-action: manipulation;
-    border-radius: 4px;
+    border-radius: 5px;
+    border-radius: var(--small-radius);
 }
 
 button {

--- a/xiplot/assets/stylesheet.css
+++ b/xiplot/assets/stylesheet.css
@@ -4,11 +4,9 @@
     --placeholder-color: #aaa;
     --body-bg-color: white;
     --control-bg-color: #dffcde;
-    --graph-bg-color: #e5ecf6;
     --smiles-img-bg-color: white;
     --bg-color: white;
     --bg-disabled-color: #dfecde;
-    --graph-stroke: white;
     --tab-underline: #adb5bd;
     --selected-tab-underline: #198754;
     --base-column-size: 30%;
@@ -22,11 +20,9 @@
     --placeholder-color: #a0aaba;
     --body-bg-color: #121212;
     --control-bg-color: #212121;
-    --graph-bg-color: #1F2833;
     --smiles-img-bg-color: #e5ecf6;
     --bg-color: #212121;
     --bg-disabled-color: #161616;
-    --graph-stroke: #3f3f3f;
     --tab-underline: #45A29E;
     --selected-tab-underline: #D6D6D6;
 }

--- a/xiplot/assets/stylesheet.css
+++ b/xiplot/assets/stylesheet.css
@@ -12,6 +12,8 @@
     --base-column-size: 30%;
     --panel-padding: 10px;
     --plot-height: 450px;
+    --large-radius: 8px;
+    --small-radius: 5px;
 }
 
 [data-theme="dark"] {
@@ -73,7 +75,8 @@ body {
     background-color: #dffcde;
     background-color: var(--control-bg-color);
     height: auto;
-    border-radius: 8px;
+    border-radius: 5px;
+    border-radius: var(--small-radius);
     box-shadow: 0px 4px 5px 0px hsla(0, 0%, 0%, 0.14),
         0px 1px 10px 0px hsla(0, 0%, 0%, 0.12),
         0px 2px 4px -1px hsla(0, 0%, 0%, 0.2);
@@ -110,6 +113,7 @@ body {
     background-color: #dffcde !important;
     background-color: var(--control-bg-color) !important;
     border-radius: 8px;
+    border-radius: var(--large-radius);
     box-shadow: 0px 4px 5px 0px hsla(0, 0%, 0%, 0.14),
         0px 1px 10px 0px hsla(0, 0%, 0%, 0.12),
         0px 2px 4px -1px hsla(0, 0%, 0%, 0.2);
@@ -124,6 +128,8 @@ body {
     margin-left: auto;
     margin-right: auto;
     background-color: var(--smiles-img-bg-color);
+    border-radius: 8px;
+    border-radius: var(--large-radius);
 }
 
 .plot-container.plotly>div {

--- a/xiplot/plots/barplot.py
+++ b/xiplot/plots/barplot.py
@@ -39,9 +39,12 @@ class Barplot(APlot):
             Input("clusters_column_store", "data"),
             Input("data_frame_store", "data"),
             Input("pca_column_store", "data"),
+            Input("plotly-template", "data"),
             prevent_initial_call=False,
         )
-        def tmp(x_axis, y_axis, selected_clusters, order, kmeans_col, df, pca_cols):
+        def tmp(
+            x_axis, y_axis, selected_clusters, order, kmeans_col, df, pca_cols, template
+        ):
             try:
                 if ctx.triggered_id == "data_frame_store":
                     raise PreventUpdate()
@@ -60,6 +63,7 @@ class Barplot(APlot):
                         kmeans_col,
                         df_from_store(df),
                         pca_cols,
+                        template,
                     ),
                     dash.no_update,
                 )
@@ -126,7 +130,16 @@ class Barplot(APlot):
         return [tmp]
 
     @staticmethod
-    def render(x_axis, y_axis, selected_clusters, order, kmeans_col, df, pca_cols=[]):
+    def render(
+        x_axis,
+        y_axis,
+        selected_clusters,
+        order,
+        kmeans_col,
+        df,
+        pca_cols=[],
+        template=None,
+    ):
         if len(kmeans_col) == df.shape[0]:
             df["Clusters"] = kmeans_col
         if not "frequency" in df.columns:
@@ -251,6 +264,7 @@ class Barplot(APlot):
                 x_axis: False,
             },
             color_discrete_map=cluster_colours(),
+            template=template,
         )
 
         fig.update_layout(
@@ -328,17 +342,7 @@ class Barplot(APlot):
         order = config.get("order", "reldiff")
 
         return [
-            dcc.Graph(
-                id={"type": "barplot", "index": index},
-                figure=Barplot.render(
-                    x_axis,
-                    y_axis,
-                    classes,
-                    order,
-                    ["all" for _ in range(len(df))],
-                    df,
-                ),
-            ),
+            dcc.Graph(id={"type": "barplot", "index": index}),
             layout_wrapper(
                 component=dcc.Dropdown(
                     id={"type": "barplot_x_axis", "index": index},

--- a/xiplot/plots/barplot.py
+++ b/xiplot/plots/barplot.py
@@ -43,7 +43,14 @@ class Barplot(APlot):
             prevent_initial_call=False,
         )
         def tmp(
-            x_axis, y_axis, selected_clusters, order, kmeans_col, df, pca_cols, template
+            x_axis,
+            y_axis,
+            selected_clusters,
+            order,
+            kmeans_col,
+            df,
+            pca_cols,
+            template=None,
         ):
             try:
                 if ctx.triggered_id == "data_frame_store":

--- a/xiplot/plots/heatmap.py
+++ b/xiplot/plots/heatmap.py
@@ -24,8 +24,10 @@ class Heatmap(APlot):
             Input({"type": "heatmap_feature_dropdown", "index": MATCH}, "value"),
             Input("data_frame_store", "data"),
             Input("pca_column_store", "data"),
+            Input("plotly-template", "data"),
+            prevent_initial_call=False,
         )
-        def tmp(n_clusters, features, df, pca_cols):
+        def tmp(n_clusters, features, df, pca_cols, template):
             # Try branch for testing
             try:
                 if ctx.triggered_id == "data_frame_store":
@@ -35,7 +37,9 @@ class Heatmap(APlot):
             except:
                 pass
 
-            return Heatmap.render(n_clusters, features, df_from_store(df), pca_cols)
+            return Heatmap.render(
+                n_clusters, features, df_from_store(df), pca_cols, template
+            )
 
         @app.callback(
             Output({"type": "heatmap_feature_dropdown", "index": MATCH}, "options"),
@@ -106,7 +110,7 @@ class Heatmap(APlot):
         return [tmp]
 
     @staticmethod
-    def render(n_clusters, features, df, pca_cols=[]):
+    def render(n_clusters, features, df, pca_cols=[], template=None):
         from sklearn.cluster import KMeans
 
         km = KMeans(n_clusters=n_clusters, random_state=42)
@@ -128,6 +132,7 @@ class Heatmap(APlot):
             y=[str(n + 1) for n in range(n_clusters)],
             color_continuous_scale="RdBu",
             origin="lower",
+            template=template,
         )
         return fig
 
@@ -159,10 +164,7 @@ class Heatmap(APlot):
 
         num_columns = get_numeric_columns(df, columns)
         return [
-            dcc.Graph(
-                id={"type": "heatmap", "index": index},
-                figure=Heatmap.render(n_clusters, num_columns, df),
-            ),
+            dcc.Graph(id={"type": "heatmap", "index": index}),
             layout_wrapper(
                 component=dcc.Dropdown(
                     options=num_columns,

--- a/xiplot/plots/heatmap.py
+++ b/xiplot/plots/heatmap.py
@@ -27,7 +27,7 @@ class Heatmap(APlot):
             Input("plotly-template", "data"),
             prevent_initial_call=False,
         )
-        def tmp(n_clusters, features, df, pca_cols, template):
+        def tmp(n_clusters, features, df, pca_cols, template=None):
             # Try branch for testing
             try:
                 if ctx.triggered_id == "data_frame_store":

--- a/xiplot/plots/heatmap.py
+++ b/xiplot/plots/heatmap.py
@@ -140,28 +140,10 @@ class Heatmap(APlot):
     def create_layout(index, df, columns, config=dict()):
         jsonschema.validate(
             instance=config,
-            schema=dict(
-                type="object",
-                properties=dict(
-                    clusters=dict(
-                        type="object",
-                        properties=dict(
-                            amount=dict(
-                                type="integer",
-                                minimum=2,
-                                maximum=10,
-                            ),
-                        ),
-                    ),
-                ),
-            ),
+            schema=dict(type="object", properties=dict(clusters=dict(type="integer"))),
         )
 
-        try:
-            n_clusters = config["clusters"]["amount"]
-        except Exception:
-            n_clusters = 2
-
+        n_clusters = config.get("clusters", 2)
         num_columns = get_numeric_columns(df, columns)
         return [
             dcc.Graph(id={"type": "heatmap", "index": index}),

--- a/xiplot/plots/histogram.py
+++ b/xiplot/plots/histogram.py
@@ -29,7 +29,7 @@ class Histogram(APlot):
             Input("plotly-template", "data"),
             prevent_initial_call=False,
         )
-        def tmp(x_axis, selected_clusters, kmeans_col, df, pca_cols, template):
+        def tmp(x_axis, selected_clusters, kmeans_col, df, pca_cols, template=None):
             # Try branch for testing
             try:
                 if ctx.triggered_id == "data_frame_store":
@@ -173,7 +173,7 @@ class Histogram(APlot):
         ]
 
 
-def make_fig_property(df, x_axis, selected_clusters, clusters, template):
+def make_fig_property(df, x_axis, selected_clusters, clusters, template=None):
     if type(selected_clusters) == str:
         selected_clusters = [selected_clusters]
 

--- a/xiplot/plots/scatterplot.py
+++ b/xiplot/plots/scatterplot.py
@@ -35,6 +35,7 @@ class Scatterplot(APlot):
             Input("clusters_column_store", "data"),
             Input("data_frame_store", "data"),
             Input("pca_column_store", "data"),
+            Input("plotly-template", "data"),
             prevent_initial_call=False,
         )
         def tmp(
@@ -47,6 +48,7 @@ class Scatterplot(APlot):
             kmeans_col,
             df,
             pca_cols,
+            template,
         ):
             # Try branch for testing
             try:
@@ -68,6 +70,7 @@ class Scatterplot(APlot):
                 selected_rows,
                 kmeans_col,
                 pca_cols,
+                template,
             )
 
             if fig is None:
@@ -272,6 +275,7 @@ class Scatterplot(APlot):
         selected_rows=None,
         kmeans_col=[],
         pca_cols=[],
+        template=None,
     ):
         if x_axis in ["Xiplot_PCA_1", "Xiplot_PCA_2"] and not pca_cols:
             return None
@@ -324,6 +328,7 @@ class Scatterplot(APlot):
             custom_data=["__Auxiliary__"],
             hover_data={"__Color__": False, "__Sizes__": False},
             render_mode="webgl",
+            template=template,
         )
         fig.update_layout(showlegend=False, uirevision=json.dumps([x_axis, y_axis]))
         fig.update(layout_coloraxis_showscale=False)
@@ -387,16 +392,7 @@ class Scatterplot(APlot):
         df["__Auxiliary__"] = [{"index": i} for i in range(len(df))]
 
         return [
-            dcc.Graph(
-                id={"type": "scatterplot", "index": index},
-                figure=px.scatter(
-                    df,
-                    x_axis,
-                    y_axis,
-                    custom_data=["__Auxiliary__"],
-                    render_mode="webgl",
-                ),
-            ),
+            dcc.Graph(id={"type": "scatterplot", "index": index}),
             layout_wrapper(
                 component=dcc.Dropdown(
                     id={"type": "scatter_x_axis", "index": index},

--- a/xiplot/plots/scatterplot.py
+++ b/xiplot/plots/scatterplot.py
@@ -48,7 +48,7 @@ class Scatterplot(APlot):
             kmeans_col,
             df,
             pca_cols,
-            template,
+            template=None,
         ):
             # Try branch for testing
             try:

--- a/xiplot/plugin.py
+++ b/xiplot/plugin.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Literal, Tuple, Union
 from importlib.metadata import entry_points as _entry_points
 from io import BytesIO
 from os import PathLike
-from warnings import warn as _warn
+from warnings import warn
 
 import pandas as pd
 from dash.development.base_component import Component
@@ -16,21 +16,29 @@ from dash import Dash
 
 # Export useful parts of xiplot:
 from xiplot.plots import APlot
-from xiplot.utils.components import FlexRow, DeleteButton, PdfButton, PlotData
+from xiplot.utils import generate_id
+from xiplot.utils.components import (
+    FlexRow,
+    PlotData,
+    DeleteButton,
+    PdfButton,
+    HelpButton,
+)
 
 
 # IDs for important `dcc.Store` components:
-STORE_DATAFRAME_ID = "data_frame_store"
-STORE_METADATA_ID = "metadata_store"
-STORE_HOVERED_ID = "lastly_hovered_point_store"
-STORE_CLICKED_ID = "lastly_clicked_point_store"
-STORE_SELECTED_ID = "selected_rows_store"
-
+ID_DATAFRAME = STORE_DATAFRAME_ID = "data_frame_store"
+ID_METADATA = STORE_METADATA_ID = "metadata_store"
+ID_HOVERED = STORE_HOVERED_ID = "lastly_hovered_point_store"
+ID_CLICKED = STORE_CLICKED_ID = "lastly_clicked_point_store"
+ID_SELECTED = STORE_SELECTED_ID = "selected_rows_store"
+ID_DARK_MODE = "light-dark-toggle-store"
+ID_PLOTLY_TEMPLATE = "plotly-template"
 
 # Useful CSS classes
 CSS_STRETCH_CLASS = "stretch"
 CSS_LARGE_BUTTON_CLASS = "button"
-CSS_DELTE_BUTTON_CLASS = "delete"
+CSS_DELETE_BUTTON_CLASS = "delete"
 
 
 # Helpful typehints:
@@ -103,7 +111,7 @@ def get_plugins_cached(
         try:
             loaded_plugins.append(plugin.load())
         except Exception as e:
-            _warn(f"Could not load plugin {plugin}: {e}")
+            warn(f"Could not load plugin {plugin}: {e}")
 
     get_plugins_cached.cache[plugin_type] = loaded_plugins
     return loaded_plugins

--- a/xiplot/plugin.py
+++ b/xiplot/plugin.py
@@ -32,7 +32,9 @@ ID_METADATA = STORE_METADATA_ID = "metadata_store"
 ID_HOVERED = STORE_HOVERED_ID = "lastly_hovered_point_store"
 ID_CLICKED = STORE_CLICKED_ID = "lastly_clicked_point_store"
 ID_SELECTED = STORE_SELECTED_ID = "selected_rows_store"
+# `dcc.Store` that is `True` if the dark mode is active
 ID_DARK_MODE = "light-dark-toggle-store"
+# `dcc.Store` that contains the current plotly template (used for the dark mode)
 ID_PLOTLY_TEMPLATE = "plotly-template"
 
 # Useful CSS classes

--- a/xiplot/tabs/plots.py
+++ b/xiplot/tabs/plots.py
@@ -125,11 +125,7 @@ class Plots(Tab):
                                             r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$": dict(
                                                 type="object",
                                                 properties=dict(
-                                                    type=dict(
-                                                        enum=list(
-                                                            Plots.plot_types.keys()
-                                                        )
-                                                    ),
+                                                    type=dict(type="string")
                                                 ),
                                                 required=["type"],
                                             ),
@@ -171,6 +167,19 @@ class Plots(Tab):
                 for index, config in plots.items():
                     plot_type = config["type"]
                     config = {k: v for k, v in config.items() if k != "type"}
+
+                    if not plot_type in Plots.plot_types:
+                        notifications.append(
+                            dmc.Notification(
+                                id=str(uuid.uuid4()),
+                                color="yellow",
+                                title="Warning",
+                                message=f"Unknown plot type: {plot_type}",
+                                action="show",
+                                autoClose=10000,
+                            )
+                        )
+                        continue
 
                     try:
                         layout = Plots.plot_types[plot_type].create_new_layout(

--- a/xiplot/tabs/settings.py
+++ b/xiplot/tabs/settings.py
@@ -3,11 +3,22 @@ from xiplot.utils.components import FlexRow
 from xiplot.utils.layouts import layout_wrapper
 
 from dash import html, Input, Output, dcc, State, Dash
+import plotly.io as pio
+import plotly.graph_objects as go
 
 
 class Settings(Tab):
     @staticmethod
     def register_callbacks(app: Dash, df_from_store, df_to_store):
+
+        pio.templates["xiplot_light"] = go.layout.Template(
+            layout={"paper_bgcolor": "rgba(255,255,255,0)"}
+        )
+        pio.templates["xiplot_dark"] = go.layout.Template(
+            layout={"paper_bgcolor": "rgba(0,0,0,0)"}
+        )
+        pio.templates.default = "plotly_white+xiplot_light"
+
         app.clientside_callback(
             """
             function toggleLightDarkMode(clicks, data) {
@@ -16,15 +27,16 @@ class Settings(Tab):
                 }
                 if (data) {
                     document.documentElement.setAttribute("data-theme", "dark")
-                    return ['Light mode', data]
+                    return ['Light mode', data, "plotly_dark+xiplot_dark"]
                 } else {
                     document.documentElement.setAttribute("data-theme", "light")
-                    return ['Dark mode', data]
+                    return ['Dark mode', data, "plotly_white+xiplot_light"]
                 }
             }
             """,
             Output("light-dark-toggle", "children"),
             Output("light-dark-toggle-store", "data"),
+            Output("plotly-template", "data"),
             Input("light-dark-toggle", "n_clicks"),
             State("light-dark-toggle-store", "data"),
             prevent_initial_call=False,
@@ -100,5 +112,9 @@ class Settings(Tab):
 
     @staticmethod
     def create_layout_globals():
-        # Store the dark/light state across page reloads
-        return dcc.Store(id="light-dark-toggle-store", data=False, storage_type="local")
+        globals = [
+            # Store the dark/light state across page reloads
+            dcc.Store(id="light-dark-toggle-store", data=False, storage_type="local"),
+            dcc.Store(id="plotly-template", data=None),
+        ]
+        return html.Div(globals)


### PR DESCRIPTION
Xiplot currently uses the default [Plotly template](https://plotly.com/python/templates/). I don't really like the grey background, especially for scatterplots (and especially for the slisemap plugin where I use a continuous colour). Would it be okay to switch to "plotly_white" that has a white background?

I also implemented a mechanism for switching to "plotly_dark" when the dark mode is activated.