### PR TITLE
Fixes for wasm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "xiplot"
 version = "0.2.0"
 authors = [
     { name="Akihiro Tanaka", email="akihiro.fin@gmail.com" },
-    { name="Juniper Tyree" },
+    { name="Juniper Tyree", email="juniper.tyree@helsinki.fi" },
     { name="Anton Björklund" },
     { name="Jarmo Mäkelä" },
 ]
@@ -24,18 +24,18 @@ dependencies = [
     "dash-daq ~= 0.5.0",
     "dash-extensions == 0.1.4",
     "dash-mantine-components ~= 0.10.2",
-    "feather-format ~= 0.4.1",
-    "dash-uploader ~= 0.6.0",
     "flask <= 2.1.2",
     "jsonschema ~= 4.6.0",
     "pandas ~= 1.4.2",
     "plotly ~= 5.9.0",
-    "kaleido ~= 0.2.1",
 ]
 
 [project.optional-dependencies]
 # Lazy loading of sklearn in the WASM version requires sklearn not to be a required dependency
 sklearn = ["scikit-learn >= 1.1.1"]
+uploader = ["dash-uploader ~= 0.6.0"]
+arrow = ["pyarrow ~= 11.0.0"]
+pdf = ["kaleido ~= 0.2.1"]
 dev = ["pytest", "black", "dash[testing]", "webdriver-manager", "selenium"]
 
 [project.urls]
@@ -54,4 +54,3 @@ where = ["."]
 include = ["xiplot*"]
 exclude = ["tests", "test_plugin"]
 namespaces = true
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,18 +24,17 @@ dependencies = [
     "dash-daq ~= 0.5.0",
     "dash-extensions == 0.1.4",
     "dash-mantine-components ~= 0.10.2",
+    "dash-uploader ~= 0.6.0; platform_system!='Wasm'",
     "flask <= 2.1.2",
     "jsonschema ~= 4.6.0",
+    "kaleido ~= 0.2.1; platform_system!='Wasm'",
     "pandas ~= 1.4.2",
     "plotly ~= 5.9.0",
+    "pyarrow ~= 11.0.0; platform_system!='Wasm'",
+    "scikit-learn >= 1.1.1; platform_system!='Wasm'",
 ]
 
 [project.optional-dependencies]
-# Lazy loading of sklearn in the WASM version requires sklearn not to be a required dependency
-sklearn = ["scikit-learn >= 1.1.1"]
-uploader = ["dash-uploader ~= 0.6.0"]
-arrow = ["pyarrow ~= 11.0.0"]
-pdf = ["kaleido ~= 0.2.1"]
 dev = ["pytest", "black", "dash[testing]", "webdriver-manager", "selenium"]
 
 [project.urls]

--- a/xiplot/plots/heatmap.py
+++ b/xiplot/plots/heatmap.py
@@ -62,7 +62,6 @@ class Heatmap(APlot):
                 and "Xiplot_PCA_1" not in options
                 and "Xiplot_PCA_2" not in options
             ):
-
                 options.extend(["Xiplot_PCA_1", "Xiplot_PCA_2"])
                 return options, dash.no_update, dash.no_update
 

--- a/xiplot/plots/scatterplot.py
+++ b/xiplot/plots/scatterplot.py
@@ -335,6 +335,19 @@ class Scatterplot(APlot):
     def create_layout(index, df, columns, config=dict()):
         num_columns = get_numeric_columns(df, columns)
 
+        try:
+            if config["axes"]["x"] in ("Xiplot_PCA_1", "Xiplot_PCA_2") or config[
+                "axes"
+            ]["y"] in (
+                "Xiplot_PCA_1",
+                "Xiplot_PCA_2",
+            ):
+                num_columns.append("Xiplot_PCA_1")
+                num_columns.append("Xiplot_PCA_2")
+
+        except Exception:
+            pass
+
         jsonschema.validate(
             instance=config,
             schema=dict(

--- a/xiplot/plugin.py
+++ b/xiplot/plugin.py
@@ -46,6 +46,7 @@ ACallbackPlugin = Callable[
     [Dash, Callable[[Any], pd.DataFrame], Callable[[pd.DataFrame], Any]], None
 ]
 
+
 # Helper functions:
 def placeholder_figure(text: str) -> Dict[str, Any]:
     """Display a placeholder text instead of a graph.

--- a/xiplot/tabs/data.py
+++ b/xiplot/tabs/data.py
@@ -168,6 +168,7 @@ class Data(Tab):
             Output("metadata_store", "data"),
             Output("clusters_column_store", "data"),
             Output("selected_rows_store", "data"),
+            Output("pca_column_store", "data"),
             Output("clusters_column_store_reset", "children"),
             Output("data-tab-notify-container", "children"),
             Input("submit-button", "n_clicks"),
@@ -187,6 +188,7 @@ class Data(Tab):
 
             if not filepath:
                 return (
+                    dash.no_update,
                     dash.no_update,
                     dash.no_update,
                     dash.no_update,
@@ -237,6 +239,7 @@ class Data(Tab):
                         )
                     except Exception as err:
                         return (
+                            dash.no_update,
                             dash.no_update,
                             dash.no_update,
                             dash.no_update,
@@ -312,6 +315,7 @@ class Data(Tab):
                     dash.no_update,
                     dash.no_update,
                     dash.no_update,
+                    dash.no_update,
                     dmc.Notification(
                         id=str(uuid.uuid4()),
                         color="yellow",
@@ -327,6 +331,7 @@ class Data(Tab):
             if "is_selected" in aux:
                 if aux.dtypes["is_selected"] != bool:
                     return (
+                        dash.no_update,
                         dash.no_update,
                         dash.no_update,
                         dash.no_update,
@@ -358,6 +363,7 @@ class Data(Tab):
                         dash.no_update,
                         dash.no_update,
                         dash.no_update,
+                        dash.no_update,
                         dmc.Notification(
                             id=str(uuid.uuid4()),
                             color="yellow",
@@ -370,11 +376,24 @@ class Data(Tab):
             else:
                 clusters = ["all"] * df.shape[0]
 
+            if "pca_cols" in aux:
+                pca_cols = [
+                    (
+                        float(i.strip("][").split(", ")[0]),
+                        (float(i.strip("][").split(", ")[1])),
+                    )
+                    for i in list(aux["pca_cols"].values)
+                ]
+
+            else:
+                pca_cols = None
+
             return (
                 df_store,
                 meta,
                 clusters,
                 selected_rows,
+                pca_cols,
                 str(uuid.uuid4()),
                 notification,
             )

--- a/xiplot/tabs/data.py
+++ b/xiplot/tabs/data.py
@@ -389,6 +389,7 @@ class Data(Tab):
             State("metadata_store", "data"),
             State("clusters_column_store", "data"),
             State("selected_rows_store", "data"),
+            State("pca_column_store", "data"),
             State(PlotData.get_id(ALL, ALL), "data"),
             State(generate_id(WriteFormatDropdown), "value"),
             prevent_initial_call=True,
@@ -401,6 +402,7 @@ class Data(Tab):
             meta,
             clusters,
             selected_rows,
+            pca_cols,
             plot_data,
             file_extension,
         ):
@@ -454,6 +456,9 @@ class Data(Tab):
 
                     if selected_rows is not None:
                         aux["is_selected"] = ~np.asarray(selected_rows, dtype=bool)
+
+                    if pca_cols is not None:
+                        aux["pca_cols"] = pca_cols
 
                     for data in plot_data:
                         index = data["index"]

--- a/xiplot/tabs/plots.py
+++ b/xiplot/tabs/plots.py
@@ -164,6 +164,10 @@ class Plots(Tab):
                 if len(kmeans_col) == df.shape[0]:
                     df["Clusters"] = kmeans_col
 
+                if pca_cols and len(pca_cols) == df.shape[0]:
+                    df["Xiplot_PCA_1"] = [i[0] for i in pca_cols]
+                    df["Xiplot_PCA_2"] = [i[1] for i in pca_cols]
+
                 columns = df.columns.to_list()
 
                 notifications = []

--- a/xiplot/utils/table.py
+++ b/xiplot/utils/table.py
@@ -1,5 +1,4 @@
 def get_sort_by(sort_by, selected_rows, trigger):
-
     if len(sort_by) == 0 and False not in selected_rows:
         sort_by = []
 


### PR DESCRIPTION
Small fixes to get the wasm version to run again. This PR is based on top of #23, so please disregard that extra diff for now, I'll rebase once #23 is merged.

Primarily, this PR adds import checks for the parquet and feather format and pdf export. Some formatting changes occurred since I ran black at the end.

@Aggrathon I'm unsure about the optional dependency changes - these are the packages that cannot be used (or need to be lazily loaded for sklearn) in xiplot right now, but maybe there's a better way to represent that.

Once this PR is merged I have a follow-up for the WASM branch to update it - locally everything seems to be working.