### PR TITLE
remove the dependency on dash-daq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 Untitled.ipynb
 data/
 uploads/
+node_modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 name = "xiplot"
 version = "0.2.0"
 authors = [
-    { name="Akihiro Tanaka", email="akihiro.fin@gmail.com" },
-    { name="Juniper Tyree", email="juniper.tyree@helsinki.fi" },
-    { name="Anton Björklund" },
-    { name="Jarmo Mäkelä" },
+    { name = "Akihiro Tanaka", email = "akihiro.fin@gmail.com" },
+    { name = "Juniper Tyree", email = "juniper.tyree@helsinki.fi" },
+    { name = "Anton Björklund" },
+    { name = "Jarmo Mäkelä" },
 ]
 description = "Interactive data visualization tool"
 license = { file = "LICENSE-MIT" }
@@ -21,7 +21,6 @@ classifiers = [
 ]
 dependencies = [
     "dash ~= 2.6.1",
-    "dash-daq ~= 0.5.0",
     "dash-extensions == 0.1.4",
     "dash-mantine-components ~= 0.10.2",
     "dash-uploader ~= 0.6.0; platform_system!='Emscripten'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,15 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "dash ~= 2.6.1",
+    "dash == 2.6.2",
     "dash-extensions == 0.1.4",
-    "dash-mantine-components ~= 0.10.2",
+    "dash-mantine-components == 0.10.2",
     "dash-uploader ~= 0.6.0; platform_system!='Emscripten'",
     "flask <= 2.1.2",
     "jsonschema ~= 4.6.0",
     "kaleido ~= 0.2.1; platform_system!='Emscripten'",
-    "pandas ~= 1.4.2",
-    "plotly ~= 5.9.0",
+    "pandas >= 1.4.0, < 2.0.0",
+    "plotly == 5.9.0",
     "pyarrow ~= 11.0.0; platform_system!='Emscripten'",
     "scikit-learn >= 1.1.1; platform_system!='Emscripten'",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
-dash==2.6.1
+dash==2.6.2
 dash-extensions==0.1.4
 dash-mantine-components==0.10.2
-dash-uploader==0.6.0
-feather-format==0.4.1
-flask==2.1.2
-jsonschema==4.6.0
-pandas==1.4.2
+dash-uploader~=0.6.0
+feather-format~=0.4.1
+flask<=2.1.2
+jsonschema~=4.6.0
+pandas>=1.4.0,<2.0.0
 plotly==5.9.0
-scikit-learn==1.1.1
-kaleido==0.2.1
+scikit-learn>=1.1.1
+kaleido~=0.2.1
+pyarrow~=11.0.0
 packaging<22 # Needed for dash-uploader==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 dash==2.6.1
-dash-daq==0.5.0
 dash-extensions==0.1.4
 dash-mantine-components==0.10.2
 dash-uploader==0.6.0

--- a/xiplot/plots/scatterplot.py
+++ b/xiplot/plots/scatterplot.py
@@ -159,7 +159,7 @@ class Scatterplot(APlot):
                 Input({"type": "scatterplot", "index": ALL}, "selectedData"),
                 State("clusters_column_store", "data"),
                 State("selection_cluster_dropdown", "value"),
-                State("cluster_selection_mode", "on"),
+                State("cluster_selection_mode", "value"),
             ],
         )
         def handle_cluster_drawing(


### PR DESCRIPTION
We only use dash-daq in one place, for a switch (that is not styled for the dark mode).  Here I've replaced the switch with a checkbox (with a button style to make it easier to click).

Fewer dependencies makes the installation of xiplot faster and easier (also use in #30).