### PR TITLE
Wasm without pyodide compilation (experiment)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /dist
 /node_modules
 /.vscode
+/build
+__pycache__
+*.egg-info
+/data

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install_pyodide: pyodide/.gitignore
 
 pyodide/.gitignore:
 	git submodule init pyodide
-	git submodule update pyodide
+	git submodule update --depth=1 pyodide
 
 build_pyodide: pyodide/dist/repodata.json
 
@@ -25,7 +25,7 @@ install_xiplot: xiplot/.gitignore
 
 xiplot/.gitignore:
 	git submodule init xiplot
-	git submodule update xiplot
+	git submodule update --depth=1 xiplot
 
 build_xiplot: xiplot/.gitignore
 	pip install build && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: pyodide install_pyodide build_pyodide xiplot install_xiplot build_xiplot deploy run all clean nuke
+.PHONY: pyodide install_pyodide build_pyodide xiplot install_xiplot build_xiplot deploy run all clean nuke xiplot2 deploy2
 
 all: run
 
@@ -76,3 +76,33 @@ nuke: clean
 	rm -rf node_modules
 	git submodule deinit -f xiplot
 	git submodule deinit -f pyodide
+
+xiplot2: install_xiplot
+	# Remove the dependency on dash-daq, and upgrade pandas to a version that has a pyodide wheel
+	curl https://github.com/edahelsinki/xiplot/commit/6d4dd80c8658b7774a3bef1df5644ee7a19a4baa.patch -o /tmp/xiplot.patch
+	cd xiplot && \
+	git apply --whitespace=nowarn /tmp/xiplot.patch && \
+	sed -i 's/"pandas ~= 1.4.2"/"pandas ~= 1.5"/' pyproject.toml && \
+	pip install build && \
+	python3 -m build && \
+	sed -i 's/"pandas ~= 1.5"/"pandas ~= 1.4.2"/' pyproject.toml && \
+	git apply --whitespace=nowarn --reverse /tmp/xiplot.patch
+
+deploy2: xiplot2
+	rm -rf dist
+	mkdir dist
+	cp -r xiplot/data dist/
+	cp -r xiplot/xiplot/assets dist/
+	cp patches/bootstrap.py dist/
+	cp xiplot/dist/xiplot-*.*.*-py3-none-any.whl dist/
+	ls dist/data > dist/assets/data.ls
+	curl https://cdn.jsdelivr.net/pyodide/v0.23.0/full/pyodide.js --output-dir dist/ -O
+	echo '{"packages": {}}' > dist/repodata.json
+	cd xiplot && \
+	pip install . && \
+	pip install toml && \
+	cp ../patches/bundle-dash-app.py . && \
+	python3 bundle-dash-app.py && \
+	rm -f bundle-dash-app.py
+	npm install
+	npm run build

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ deploy: pyodide xiplot
 	cp -r xiplot/xiplot/assets dist/
 	ls dist/data > dist/assets/data.ls
 	cd xiplot && \
-	pip install -r requirements.txt && \
+	pip install . && \
 	pip install toml && \
 	cp ../patches/bundle-dash-app.py . && \
 	python3 bundle-dash-app.py && \

--- a/src/webdash.ts
+++ b/src/webdash.ts
@@ -80,6 +80,9 @@ class WebDash {
   }
 
   private async bootstrap() {
+    await this.worker_manager.executeWithAnyResponse("import micropip; micropip.install(\"setuptools\")", {});
+    await this.worker_manager.executeWithAnyResponse("micropip.add_mock_package(\"jsbeautifier\", \"1.14.3\")", {});
+    await this.worker_manager.executeWithAnyResponse("micropip.install(\"xiplot-0.2.0-py3-none-any.whl\")", {});
     await this.initialiseDashApp();
 
     await this.injectDashHeaders(document.head);
@@ -257,4 +260,3 @@ class WebDash {
 }
 
 window.web_dash = new WebDash();
- 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -89,7 +89,7 @@ onmessage = async (event: MessageEvent) => {
     if (pyodide.isPyProxy(result)) {
       result = responseObjectFromPython(result);
     }
-    
+
     postResponseMessage(uuid, result);
   } catch (error) {
     postErrorMessage(uuid, error.message);
@@ -101,7 +101,8 @@ onmessage = async (event: MessageEvent) => {
  */
 const maybe_pyodide: Promise<PyodideInterface> = loadPyodide({
   homedir: "/",
-  indexURL: "",
+  // indexURL: "", // To use local pyodide files
+  indexURL: "https://cdn.jsdelivr.net/pyodide/v0.23.0/full/", // To use CDN pyodide files
   fullStdLib: false,
   stdout: postConsoleMessage,
   stderr: postConsoleError,


### PR DESCRIPTION
This PR is not meant to be merged. This is an experiment for trying to run wasm-xiplot without compiling pyodide first. Therefore, some of the solutions are quite hacky.

__Status:__ It works!  
__Pros:__ Latest pyodide without any changes (although there are some deprecation warnings).  
__Cons:__ The name of the xiplot wheel is hardcoded and most pyodide files (including wheels) are from a CDN.