### PR TITLE
Remove flask dependency from pyproject.toml

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -4,20 +4,20 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths: ["**.py", "requirements.txt"]
+    paths: ["**.py", "requirements.txt", "requirements-dev.txt"]
   pull_request:
     branches: [main]
-    paths: ["**.py", "requirements*.txt"]
+    paths: ["**.py", "requirements*.txt", "requirements-dev.txt"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"] #, "3.11"] # Python 3.11 has trouble installing packages on GitHub
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up chome
         run: |
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install libnss3-dev google-chrome-stable
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install libnss3-dev google-chrome-stable
 
       - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "kaleido ~= 0.2.1; platform_system!='Emscripten'",
     "pandas >= 1.4.0, < 2.0.0",
     "plotly >= 5.9.0",
-    "pyarrow ~= 11.0.0; platform_system!='Emscripten'",
+    "pyarrow >= 11.0.0; platform_system!='Emscripten'",
     "scikit-learn >= 1.1.1; platform_system!='Emscripten'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,10 @@ dependencies = [
     "dash-extensions == 0.1.4",
     "dash-mantine-components == 0.10.2",
     "dash-uploader ~= 0.6.0; platform_system!='Emscripten'",
-    "flask <= 2.1.2",
     "jsonschema ~= 4.6.0",
     "kaleido ~= 0.2.1; platform_system!='Emscripten'",
     "pandas >= 1.4.0, < 2.0.0",
-    "plotly == 5.9.0",
+    "plotly >= 5.9.0",
     "pyarrow ~= 11.0.0; platform_system!='Emscripten'",
     "scikit-learn >= 1.1.1; platform_system!='Emscripten'",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ dash==2.6.2
 dash-extensions==0.1.4
 dash-mantine-components==0.10.2
 dash-uploader~=0.6.0
-feather-format~=0.4.1
+feather-format>=0.4.1
 jsonschema~=4.6.0
 pandas>=1.4.0,<2.0.0
-plotly==5.9.0
+plotly>=5.9.0
 scikit-learn>=1.1.1
 kaleido~=0.2.1
-pyarrow~=11.0.0
+pyarrow>=11.0.0
 packaging<22 # Needed for dash-uploader==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ dash-extensions==0.1.4
 dash-mantine-components==0.10.2
 dash-uploader~=0.6.0
 feather-format~=0.4.1
-flask<=2.1.2
 jsonschema~=4.6.0
 pandas>=1.4.0,<2.0.0
 plotly==5.9.0


### PR DESCRIPTION
This is related to the discussion in #30, where we noticed that unnecessarily requiring a specific version of indirect dependencies can cause trouble when installing xiplot.