### PR TITLE
Kmeans warnings

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pandas >= 1.4.0, < 2.0.0",
     "plotly >= 5.9.0",
     "pyarrow >= 11.0.0; platform_system!='Emscripten'",
-    "scikit-learn >= 1.1.1; platform_system!='Emscripten'",
+    "scikit-learn >= 1.0; platform_system!='Emscripten'",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ feather-format>=0.4.1
 jsonschema~=4.6.0
 pandas>=1.4.0,<2.0.0
 plotly>=5.9.0
-scikit-learn>=1.1.1
+scikit-learn>=1.0
 kaleido~=0.2.1
 pyarrow>=11.0.0
 packaging<22 # Needed for dash-uploader==0.6.0

--- a/xiplot/plots/barplot.py
+++ b/xiplot/plots/barplot.py
@@ -276,7 +276,6 @@ class Barplot(APlot):
 
         fig.update_layout(
             hovermode="x unified",
-            margin=dict(l=10, r=10, t=10, b=10),
             showlegend=False,
             xaxis=dict(fixedrange=True, categoryorder="array", categoryarray=top_bars),
             yaxis=dict(fixedrange=True),

--- a/xiplot/plots/heatmap.py
+++ b/xiplot/plots/heatmap.py
@@ -6,6 +6,7 @@ from dash import html, dcc, Output, Input, State, MATCH, ALL, ctx
 from dash.exceptions import PreventUpdate
 from xiplot.utils.components import DeleteButton, PdfButton, PlotData
 
+from xiplot.utils.cluster import KMeans
 from xiplot.utils.layouts import layout_wrapper
 from xiplot.utils.dataframe import get_numeric_columns
 from xiplot.utils.regex import dropdown_regex, get_columns_by_regex
@@ -110,8 +111,6 @@ class Heatmap(APlot):
 
     @staticmethod
     def render(n_clusters, features, df, pca_cols=[], template=None):
-        from sklearn.cluster import KMeans
-
         km = KMeans(n_clusters=n_clusters, random_state=42)
         df = add_pca_columns_to_df(df, pca_cols)
         dff = df.dropna()

--- a/xiplot/plots/heatmap.py
+++ b/xiplot/plots/heatmap.py
@@ -7,6 +7,7 @@ from dash.exceptions import PreventUpdate
 from xiplot.utils.components import DeleteButton, PdfButton, PlotData
 
 from xiplot.utils.cluster import KMeans
+from xiplot.utils.components import FlexRow
 from xiplot.utils.layouts import layout_wrapper
 from xiplot.utils.dataframe import get_numeric_columns
 from xiplot.utils.regex import dropdown_regex, get_columns_by_regex
@@ -130,6 +131,7 @@ class Heatmap(APlot):
             y=[str(n + 1) for n in range(n_clusters)],
             color_continuous_scale="RdBu",
             origin="lower",
+            aspect="auto",
             template=template,
         )
         return fig
@@ -141,39 +143,42 @@ class Heatmap(APlot):
             schema=dict(type="object", properties=dict(clusters=dict(type="integer"))),
         )
 
-        n_clusters = config.get("clusters", 2)
+        n_clusters = config.get("clusters", 5)
         num_columns = get_numeric_columns(df, columns)
         return [
             dcc.Graph(id={"type": "heatmap", "index": index}),
-            layout_wrapper(
-                component=dcc.Dropdown(
-                    options=num_columns,
-                    multi=True,
-                    id={"type": "heatmap_feature_dropdown", "index": index},
-                    clearable=False,
+            FlexRow(
+                layout_wrapper(
+                    component=dcc.Dropdown(
+                        options=num_columns,
+                        multi=True,
+                        id={"type": "heatmap_feature_dropdown", "index": index},
+                        clearable=False,
+                    ),
+                    title="Features",
+                    css_class="dash-dropdown",
                 ),
-                title="Features",
-                style={"width": "80%"},
-            ),
-            html.Button(
-                "Add features by regex",
-                id={"type": "heatmap_regex-button", "index": index},
-            ),
-            layout_wrapper(
-                component=dcc.Input(
-                    id={"type": "heatmap_feature-input", "index": index}
+                html.Button(
+                    "Add features by regex",
+                    id={"type": "heatmap_regex-button", "index": index},
+                    className="button",
                 ),
-                style={"display": "none"},
-            ),
-            layout_wrapper(
-                component=dcc.Slider(
-                    min=2,
-                    max=10,
-                    step=1,
-                    value=n_clusters,
-                    id={"type": "heatmap_cluster_amount", "index": index},
+                layout_wrapper(
+                    component=dcc.Input(
+                        id={"type": "heatmap_feature-input", "index": index}
+                    ),
+                    style={"display": "none"},
                 ),
-                title="Cluster amount",
-                style={"width": "80%"},
-            ),
+                layout_wrapper(
+                    component=dcc.Slider(
+                        min=2,
+                        max=10,
+                        step=1,
+                        value=n_clusters,
+                        id={"type": "heatmap_cluster_amount", "index": index},
+                    ),
+                    title="Number of clusters",
+                    css_class="dash-dropdown",
+                ),
+            )
         ]

--- a/xiplot/plots/histogram.py
+++ b/xiplot/plots/histogram.py
@@ -214,7 +214,6 @@ def make_fig_property(df, x_axis, selected_clusters, clusters, template=None):
 
     fig_property.update_layout(
         hovermode="x unified",
-        margin=dict(l=10, r=10, t=10, b=10),
         showlegend=False,
         barmode="overlay",
         yaxis=dict(

--- a/xiplot/tabs/cluster.py
+++ b/xiplot/tabs/cluster.py
@@ -15,7 +15,7 @@ from xiplot.tabs import Tab
 from xiplot.utils.layouts import layout_wrapper, cluster_dropdown
 from xiplot.utils.regex import dropdown_regex, get_columns_by_regex
 from xiplot.utils.dataframe import get_numeric_columns
-from xiplot.utils.cluster import cluster_colours
+from xiplot.utils.cluster import cluster_colours, KMeans
 from xiplot.utils.components import FlexRow
 
 
@@ -413,7 +413,6 @@ class Cluster(Tab):
         ):
             return kmeans_col
 
-        from sklearn.cluster import KMeans
         from sklearn.preprocessing import StandardScaler
 
         scaler = StandardScaler()

--- a/xiplot/tabs/cluster.py
+++ b/xiplot/tabs/cluster.py
@@ -168,7 +168,7 @@ class Cluster(Tab):
             message = "The k-means clustering process has started."
 
             if "sklearn" not in sys.modules:
-                message += " [sklearn has to first be loaded lazily]"
+                message += " [Loading scikit-learn]"
 
             return process_id, dmc.Notification(
                 id=process_id,

--- a/xiplot/tabs/embedding.py
+++ b/xiplot/tabs/embedding.py
@@ -117,7 +117,7 @@ class Embedding(Tab):
             message = "The embedding process has started."
 
             if "sklearn" not in sys.modules:
-                message += " [sklearn has to first be loaded lazily]"
+                message += " [Loading scikit-learn]"
 
             return process_id, dmc.Notification(
                 id=process_id,

--- a/xiplot/tabs/settings.py
+++ b/xiplot/tabs/settings.py
@@ -11,10 +11,18 @@ class Settings(Tab):
     @staticmethod
     def register_callbacks(app: Dash, df_from_store, df_to_store):
         pio.templates["xiplot_light"] = go.layout.Template(
-            layout={"paper_bgcolor": "rgba(255,255,255,0)"}
+            layout={
+                "paper_bgcolor": "rgba(255,255,255,0)",
+                "margin": dict(l=10, r=10, t=10, b=10, autoexpand=True),
+                "uirevision": True,
+            }
         )
         pio.templates["xiplot_dark"] = go.layout.Template(
-            layout={"paper_bgcolor": "rgba(0,0,0,0)"}
+            layout={
+                "paper_bgcolor": "rgba(0,0,0,0)",
+                "margin": dict(l=10, r=10, t=10, b=10, autoexpand=True),
+                "uirevision": True,
+            }
         )
         pio.templates.default = "plotly_white+xiplot_light"
 

--- a/xiplot/utils/cluster.py
+++ b/xiplot/utils/cluster.py
@@ -6,3 +6,25 @@ def cluster_colours():
         "all": px.colors.qualitative.Vivid[-1],
         **{f"c{i+1}": c for i, c in enumerate(px.colors.qualitative.Vivid[:-1])},
     }
+
+
+def KMeans(n_clusters: int = 8, **kwargs) -> object:
+    """A wrapper around `sklearn.cluster.KMeans` that changes `n_init="warn"` to `n_init="auto"`.
+    This is needed to avoid a warning for sklearn versions `>=1.2,<1.4`.
+    Older and newer versions are not affected (unless `n_init="warn"` is manually specified).
+
+    NOTE: This function lazily loads scikit-learn (so the first call might be slow)
+
+    Args:
+        n_clusters: The number of clusters. Defaults to 8.
+        **kwargs: See `sklearn.cluster.KMeans`.
+
+    Returns:
+        An instance of `sklearn.cluster.KMeans`.
+    """
+    from sklearn.cluster import KMeans
+
+    km = KMeans(n_clusters, **kwargs)
+    if km.n_init == "warn":
+        km.n_init == "auto"
+    return km

--- a/xiplot/utils/cluster.py
+++ b/xiplot/utils/cluster.py
@@ -10,7 +10,7 @@ def cluster_colours():
 
 def KMeans(n_clusters: int = 8, **kwargs) -> object:
     """A wrapper around `sklearn.cluster.KMeans` that changes `n_init="warn"` to `n_init="auto"`.
-    This is needed to avoid a warning for sklearn versions `>=1.2,<1.4`.
+    This is needed to avoid a warning for scikit-learn versions `>=1.2,<1.4`.
     Older and newer versions are not affected (unless `n_init="warn"` is manually specified).
 
     NOTE: This function lazily loads scikit-learn (so the first call might be slow)


### PR DESCRIPTION
Since *sklearn* 1.2 there is a warning when using `KMeans` without specifying `n_init`. This PR creates a wrapper for `KMeans` that takes care of the warning in a backward and forward compatible manner. (These warnings look scarier than they are in the WASM branch #30.)

This PR also enlargens the heatmap by setting `aspect="auto"`. Additionally, the margins for the plots is moved to the templates so that all plots have the same margins.