### PR TITLE
Do not use werkzeug>=3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xiplot"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     { name = "Akihiro Tanaka", email = "akihiro.fin@gmail.com" },
     { name = "Juniper Tyree", email = "juniper.tyree@helsinki.fi" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "plotly >= 5.9.0",
     "scikit-learn >= 1.0; platform_system!='Emscripten'",
     "xiplot_filetypes == 1.0; platform_system!='Emscripten'",
+    "Werkzeug < 3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ plotly>=5.9.0
 scikit-learn>=1.0
 kaleido~=0.2.1
 packaging<22 # Needed for dash-uploader==0.6.0
+Werkzeug<3.0.0 # Needed for flask 2.X.X
 ./plugin_xiplot_filetypes


### PR DESCRIPTION
Flask has an open ended dependency on Werkzeug. However, `Werkzeug>=3.0.0` is incompatible with older versions of Flask (which we are using due to an old version of Dash).